### PR TITLE
Bugfix/ensure only dart files added to generated coverage file

### DIFF
--- a/bin/generate_dart_file.dart
+++ b/bin/generate_dart_file.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:path/path.dart';
 
 import 'utils/reg_exp_utils.dart';
 
@@ -93,6 +94,10 @@ Future<List<String>> _listDir(String folderPath, {RegExp regExp}) async {
     await for (FileSystemEntity entity in directory.list(recursive: true, followLinks: false)) {
       FileSystemEntityType type = await FileSystemEntity.type(entity.path);
       if (type == FileSystemEntityType.file) {
+        if (!_isDartFile(entity)) {
+          continue;
+        }
+
         if (regExp != null) {
           if (regExp.hasMatch(entity.path)) {
             continue;
@@ -106,4 +111,10 @@ Future<List<String>> _listDir(String folderPath, {RegExp regExp}) async {
   }
 
   return paths;
+}
+
+/// Determines if a [FileSystemEntity] is a dart file
+bool _isDartFile(FileSystemEntity entity) {
+  const dartFileExtension = '.dart';
+  return extension(entity.path).toLowerCase() == dartFileExtension;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -8,5 +8,12 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.0"
+  path:
+    dependency: "direct main"
+    description:
+      name: path
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.7.0"
 sdks:
   dart: ">=2.7.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,9 +3,12 @@ description: A package with helpers for generating and editing code coverage rep
 version: 0.0.1
 publish_to: 'none'
 homepage: https://github.com/defuncart/dart_code_coverage
+repository: https://github.com/defuncart/dart_code_coverage
+issue_tracker: https://github.com/defuncart/dart_code_coverage/issues
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
   args: ^1.6.0
+  path: ^1.6.4


### PR DESCRIPTION
Fixes a bug where non-dart files in lib would also be added to `coverage_report_test.dart`.